### PR TITLE
Support for specifying table names & error emitting

### DIFF
--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -36,7 +36,10 @@ module.exports = function(options) {
     pg.connect(options.db, connected);
 
     function connected(err, db, cb) {
-      if (err) return complete(err);
+      if (err) {
+        Jobs.eventEmitter.emit("createError", err);
+        return complete(err);
+      }
 
       jobsModel.write(db, null, processIn, jobData, complete, options.table);
 
@@ -95,7 +98,10 @@ module.exports = function(options) {
     pg.connect(options.db, connected);
 
     function connected(err, db, releaseClient) {
-      if (err) return done(err);
+      if (err) {
+        Jobs.eventEmitter.emit("connectionError", err);
+        return done(err);
+      }
       async.whilst(Jobs.continueProcessing, iterator, finish);
 
       function iterator(callback) {
@@ -107,6 +113,7 @@ module.exports = function(options) {
       }
       function finish(err) {
         releaseClient();
+        Jobs.eventEmitter.emit('processError', err);
         Jobs.eventEmitter.emit('stopProcess');
         done();
       }
@@ -118,7 +125,10 @@ module.exports = function(options) {
     pg.connect(options.db, connected);
 
     function connected(err, db, releaseClient) {
-      if (err) return done(err);
+      if (err) {
+        Jobs.eventEmitter.emit("connectionError", err);
+        return done(err);
+      }
       jobsModel.obtainLock(db, jobId, getJobProcessor(true, db, processFunction, function(err) {
         releaseClient();
         done(err);

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -16,6 +16,8 @@ module.exports = function(options) {
   var Jobs = {};
   var jobsModel = require('../models/jobs');
 
+  options.table = options.table || "job_snapshots";
+
   // Expose jobs model when we are testing so we can set up stuff on the Db.
   if (process.env.NODE_ENV === 'test') {
     Jobs.jobsModel = jobsModel;
@@ -36,7 +38,7 @@ module.exports = function(options) {
     function connected(err, db, cb) {
       if (err) return complete(err);
 
-      jobsModel.write(db, null, processIn, jobData, complete);
+      jobsModel.write(db, null, processIn, jobData, complete, options.table);
 
       function complete(err, jobId) {
         cb(); // Return the client to the pool
@@ -46,7 +48,7 @@ module.exports = function(options) {
   };
 
   function updateJob(db, jobSnapshot, newJobData, processIn, cb) {
-    jobsModel.write(db, jobSnapshot.job_id, processIn, newJobData, complete);
+    jobsModel.write(db, jobSnapshot.job_id, processIn, newJobData, complete, options.table);
 
     function complete(err) {
       if (err) return cb(err);
@@ -63,7 +65,7 @@ module.exports = function(options) {
       if (err) {
         return callback(err);
       } else {
-        jobsModel.setProcessedNow(db, jobContainer.job_id);
+        jobsModel.setProcessedNow(db, jobContainer.job_id, options.table);
         updateJob(db, jobContainer, newJobData, processIn, callback);
       }
     }
@@ -100,7 +102,7 @@ module.exports = function(options) {
         setImmediate(function() {
           Jobs.eventEmitter.emit('maybeServiceJob');
           debug('Getting next job to process...');
-          jobsModel.nextToProcess(db, getJobProcessor(false, db, processFunction, callback));
+          jobsModel.nextToProcess(db, getJobProcessor(false, db, processFunction, callback), options.table);
         });
       }
       function finish(err) {
@@ -120,7 +122,7 @@ module.exports = function(options) {
       jobsModel.obtainLock(db, jobId, getJobProcessor(true, db, processFunction, function(err) {
         releaseClient();
         done(err);
-      }));
+      }), options.table);
       Jobs.eventEmitter.emit('lockSought');
     }
   };

--- a/models/sql.js
+++ b/models/sql.js
@@ -1,4 +1,4 @@
-exports.obtainNextUnlockedJob =
+exports.obtainNextUnlockedJob = function(tableName) {
   // Cf the PG doco on "WITH RECURSIVE" to understand this.
   // http://www.postgresql.org/docs/9.3/static/queries-with.html. Note that it
   // is a little confusing and slightly inaccurate at time of writing.
@@ -9,60 +9,63 @@ exports.obtainNextUnlockedJob =
   // have been through the whole table or have managed to lock a job.
   // The final select section at the end runs when the "recursive" section
   // did not add any row to the temp table last time it ran.
-    "WITH RECURSIVE candidate_job AS (" +
+  return "WITH RECURSIVE candidate_job AS (" +
     // Run this first, see whether the first one is locked.
     // Row will come into the temp table along with whether locked.
     // We have to nest the query as the limit will not necessarily
     // be applied before the lock if we do it all in one, hence
     // we could then lock unforseen jobs.
-    "SELECT (j).*, pg_try_advisory_lock((j).id) AS locked " +
-    "FROM ( " +
-      "SELECT j " +
-      "FROM job_snapshots AS j " +
-      "WHERE process_at IS NOT NULL AND process_at <= now() AND processed IS NULL " +
-      "ORDER BY process_at, id " +
-      "LIMIT 1 " +
-    ") AS t1 " +
+  "SELECT (j).*, pg_try_advisory_lock((j).id) AS locked " +
+  "FROM ( " +
+  "SELECT j " +
+  "FROM " + tableName + " AS j " +
+  "WHERE process_at IS NOT NULL AND process_at <= now() AND processed IS NULL " +
+  "ORDER BY process_at, id " +
+  "LIMIT 1 " +
+  ") AS t1 " +
     // This will keep outputting a new row whilst ever the last row in the
     // temp table was not successfully locked. It will replace what is in the
     // temp table.
-    "UNION ALL ( " +
-      "SELECT (j).*, pg_try_advisory_lock((j).id) AS locked " +
-      "FROM ( " +
-        "SELECT ( " +
-          "SELECT j " +
-          "FROM job_snapshots AS j " +
-          "WHERE process_at IS NOT NULL AND process_at <= now() AND processed IS NULL " +
-          // Get the next one in line after the one we tried to lock.
-          "AND (process_at, id) > (candidate_job.process_at, candidate_job.id) " +
-          "ORDER BY process_at, id " +
-          "LIMIT 1 " +
-        ") AS j " +
-        "FROM candidate_job " +
-        // Only output the row for next iteration iff we did NOT obtain a lock.
-        // Else, the row that we did manage to lock is left in the temp table
-        // for the query below to pick up.
-        "WHERE NOT candidate_job.locked " +
-        "LIMIT 1 " +
-      ") AS t1 " +
-    ") " +
+  "UNION ALL ( " +
+  "SELECT (j).*, pg_try_advisory_lock((j).id) AS locked " +
+  "FROM ( " +
+  "SELECT ( " +
+  "SELECT j " +
+  "FROM " + tableName + " AS j " +
+  "WHERE process_at IS NOT NULL AND process_at <= now() AND processed IS NULL " +
+    // Get the next one in line after the one we tried to lock.
+  "AND (process_at, id) > (candidate_job.process_at, candidate_job.id) " +
+  "ORDER BY process_at, id " +
+  "LIMIT 1 " +
+  ") AS j " +
+  "FROM candidate_job " +
+    // Only output the row for next iteration iff we did NOT obtain a lock.
+    // Else, the row that we did manage to lock is left in the temp table
+    // for the query below to pick up.
+  "WHERE NOT candidate_job.locked " +
+  "LIMIT 1 " +
+  ") AS t1 " +
   ") " +
-  // We should just be left with the job we managed to lock, or we went through
-  // them all and couldn't lock one, in which case we'll be left with the last
-  // one we couldn't. (Hence the "where locked" so we get an empty result set
-  // in that case).
-  "SELECT * FROM job_snapshots " +
+  ") " +
+    // We should just be left with the job we managed to lock, or we went through
+    // them all and couldn't lock one, in which case we'll be left with the last
+    // one we couldn't. (Hence the "where locked" so we get an empty result set
+    // in that case).
+  "SELECT * FROM " + tableName + " " +
   "WHERE id IN (SELECT id FROM candidate_job WHERE locked)";
+};
 
 exports.unlockJob = "SELECT pg_advisory_unlock($1);";
 
-exports.obtainLockForJob =
-  "SELECT *, pg_advisory_lock(id) FROM job_snapshots " +
+exports.obtainLockForJob = function(tableName){
+  return "SELECT *, pg_advisory_lock(id) FROM " + tableName + " " +
   "WHERE job_id = $1 AND processed IS NULL";
+};
 
-exports.setProcessedNow =
-  "UPDATE job_snapshots " +
+exports.setProcessedNow = function(tableName) {
+  return "UPDATE " + tableName + " " +
   "SET processed = NOW() " +
   "WHERE job_id = $1 AND processed IS NULL";
+};
 
 // vim: set et sw=2 ts=2 colorcolumn=80:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-jobs",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A simple yet powerful postgres backed job queue for node.js.",
   "main": "index.js",
   "directories": {
@@ -30,11 +30,11 @@
     "sinon": "~1.7.3"
   },
   "dependencies": {
-    "async": "~0.2.9",
+    "async": "~1.2.0",
     "debug": "^2.0.0",
-    "lodash": "~2.4.1",
+    "lodash": "~3.9.3",
     "moment": "~2.5.0",
-    "pg": "~2.11.1",
+    "pg": "~4.4.0",
     "pg-transaction": "^1.0.4",
     "sql": "~0.35.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-jobs",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A simple yet powerful postgres backed job queue for node.js.",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-jobs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A simple yet powerful postgres backed job queue for node.js.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Table name can now be specified in the initialization options. I've also added some error events since most applications will want to know about them. This shouldn't be a breaking change - table name defaults to "job_snapshots" if not specified. 
